### PR TITLE
【パスワード変更機能】現在のパスワードが違うときのエラーレスポンスのタイポを修正

### DIFF
--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -47,7 +47,7 @@ const userController = {
       // 現在のパスワードの検証
       if (!bcrypt.compareSync(req.body.currentPassword, user.password)) {
         // エラーメッセージ
-        res.status(400).json({ massage: 'Invalid current password' });
+        res.status(400).json({ message: 'Invalid current password' });
         return;
       }
       // 新しいパスワードをハッシュ化


### PR DESCRIPTION
## Issue
#18 

## 内容
- パスワード変更時に現在のパスワードが違う場合に送信するエラーのレスポンスにタイポがあったので修正