### PR TITLE
【投稿モデル】投稿取得用ミドルウェアから投稿者のデータを取得できるように変更

### DIFF
--- a/controllers/post-controller.js
+++ b/controllers/post-controller.js
@@ -1,6 +1,7 @@
 const db = require('../models/index');
 
-const attributes = ['id', 'title', 'text', 'updatedAt', 'authorId'];
+const attributes = ['id', 'title', 'text', 'updatedAt'];
+const userAttributes = ['username', 'icon_url']
 
 const postController = {
   // 投稿一覧取得
@@ -10,6 +11,7 @@ const postController = {
         ['updatedAt', 'DESC'], // 投稿日時が遅い順
       ],
       attributes,
+      include: { model: db.user, attributes: userAttributes }
     })
       .then(posts => {
         res.json(posts);
@@ -26,6 +28,7 @@ const postController = {
         ['updatedAt', 'DESC'],
       ],
       attributes,
+      include: { model: db.user, attributes: userAttributes }
     })
       .then(posts => {
         res.json(posts);
@@ -42,6 +45,7 @@ const postController = {
         ['updatedAt', 'DESC']
       ],
       attributes,
+      include: { model: db.user, attributes: userAttributes }
     })
       .then(posts => {
         res.json(posts);
@@ -52,7 +56,10 @@ const postController = {
   },
   // 特定の投稿を取得
   getPost(req, res, next) {
-    db.post.findByPk(req.params.postId, { attributes })
+    db.post.findByPk(req.params.postId, {
+      attributes,
+      include: { model: db.user, attributes: userAttributes }
+    })
       .then(result => {
         res.json(result);
       })


### PR DESCRIPTION
## Issue
#22 

## 内容
- 投稿取得用ミドルウェアから投稿者のデータを取得できるように変更
  - 投稿の取得を行うミドルウェアのSequelizeのメソッドの設定にincludeを追加し、関連先モデルであるUserモデルからデータを一緒に取得できるように変更