### PR TITLE
【投稿お気に入り機能】ユーザーがお気に入りの投稿を登録・一覧取得・削除できる機能を作成

### DIFF
--- a/controllers/post-controller.js
+++ b/controllers/post-controller.js
@@ -97,6 +97,31 @@ const postController = {
         next(err);
       })
   },
+  // お気に入りの投稿を作成
+  setFavoritePost(req, res, next) {
+    Promise.all([
+      db.user.findByPk(req.body.userId),
+      db.post.findByPk(req.body.postId)
+    ]).then(values => {
+      values[0].setPosts(values[1]);
+      res.end();
+    }).catch(err => {
+      next(err);
+    });
+  },
+  // お気に入りの投稿を削除
+  removeFavoritePost(req, res, next) {
+    db.UserPost.destroy({
+      where: {
+        userId: req.params.userId,
+        postId: req.params.postId,
+      }
+    }).then(() => {
+      res.end();
+    }).catch(err => {
+      next(err);
+    })
+  },
   // エラーハンドリング
   errorHandling(err, req, res, next) {
     if (err) {

--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -1,6 +1,8 @@
 const db = require('../models/index');
 const bcrypt = require('bcrypt');
 
+const favoritePostsAssociation = { model: db.post, as: 'favoritePosts' };
+
 const userController = {
   // ユーザー一覧取得
   getUsers(req, res, next) {
@@ -89,6 +91,16 @@ const userController = {
     db.user.update(params, { where: { id: req.params.userId } })
       .then(() => {
         res.json(params);
+      })
+      .catch(err => {
+        next(err);
+      });
+  },
+  // 特定のユーザーの情報をお気に入りの投稿と一緒に取得
+  getUserWithFavoritePosts(req, res, next) {
+    db.user.findByPk(req.params.userId, { include: [favoritePostsAssociation] })
+      .then(user => {
+        res.json(user);
       })
       .catch(err => {
         next(err);

--- a/migrations/20210825103105-create-user-post.js
+++ b/migrations/20210825103105-create-user-post.js
@@ -1,0 +1,30 @@
+'use strict';
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('UserPosts', {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.UUID4,
+      },
+      userId: {
+        type: Sequelize.UUID
+      },
+      postId: {
+        type: Sequelize.UUID
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE
+      }
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('UserPosts');
+  }
+};

--- a/models/post.js
+++ b/models/post.js
@@ -2,6 +2,7 @@
 const {
   Model
 } = require('sequelize');
+const userpost = require('./userpost');
 module.exports = (sequelize, DataTypes) => {
   class post extends Model {
     /**
@@ -12,7 +13,11 @@ module.exports = (sequelize, DataTypes) => {
     static associate(models) {
       // define association here
       post.belongsTo(models.user, {
-        foreignKey: 'authorId' // authorIdをForeignKeyとする1対多の関係
+        foreignKey: 'authorId', // authorIdをForeignKeyとする1対多の関係
+        onDelete: 'CASCADE'
+      });
+      post.belongsToMany(models.user, {
+        through: models.UserPost, // お気に入りの投稿機能のための多対多の中間テーブル
       });
     }
   };

--- a/models/user.js
+++ b/models/user.js
@@ -11,6 +11,10 @@ module.exports = (sequelize, DataTypes) => {
      */
     static associate(models) {
       // define association here
+      user.belongsToMany(models.post, {
+        through: models.UserPost, // 投稿お気に入り機能のための中間テーブル
+        as: 'favoritePosts', // 参照時のフィールド名
+      });
     }
   };
   user.init({

--- a/models/userpost.js
+++ b/models/userpost.js
@@ -1,0 +1,30 @@
+'use strict';
+const {
+  Model
+} = require('sequelize');
+module.exports = (sequelize, DataTypes) => {
+  class UserPost extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here
+    }
+  };
+  UserPost.init({
+    id: {
+      allowNull: false,
+      primaryKey: true,
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    userId: DataTypes.UUID,
+    postId: DataTypes.UUID
+  }, {
+    sequelize,
+    modelName: 'UserPost',
+  });
+  return UserPost;
+};

--- a/routes/posts.js
+++ b/routes/posts.js
@@ -23,4 +23,14 @@ router.patch('/update/:postId', postController.updatePost, postController.errorH
 // 投稿を削除
 router.delete('/delete/:postId', postController.deletePost, postController.errorHandling);
 
+// お気に入りの投稿を作成
+router.post('/create/favorite', postController.setFavoritePost, postController.errorHandling);
+
+// お気に入りの投稿を削除
+router.delete(
+  '/:postId/remove/favorite/:userId',
+  postController.removeFavoritePost,
+  postController.errorHandling
+);
+
 module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -26,6 +26,13 @@ router.patch(
   '/profile/:userId/edit/noicon',
   userController.patchProfile, // ユーザー名、自己紹介のみ編集
   userController.errorHandling
-)
+);
+
+// ユーザ―情報＋そのユーザーのお気に入りの投稿
+router.get(
+  '/:userId/with/favorite/posts', 
+  userController.getUserWithFavoritePosts, 
+  userController.errorHandling
+);
 
 module.exports = router;


### PR DESCRIPTION
## Issue
#24 

## 内容
- ユーザーがお気に入りの投稿を登録・一覧取得・削除できる機能を作成
  - Sequelizeを用いてユーザー(User)モデルと投稿(Post)モデル間に多対多の関係を構築
  - 上記の関係のための中間テーブルとなるモデル(UserPost)を作成し、マイグレーションを実行
  - お気に入りの投稿を作成・一覧取得・削除できるミドルウェアを作成
  - 上記のミドルウェアのためのルートを作成