### PR TITLE
【投稿ルート】投稿のルートのURLを修正

### DIFF
--- a/routes/posts.js
+++ b/routes/posts.js
@@ -7,7 +7,7 @@ router.get('/', postController.getPosts, postController.errorHandling);
 
 // 特定数の投稿を取得
 router.get(
-  '/:page', 
+  '/page/:page', 
   postController.getPostsByPagination, 
   postController.errorHandling
 );


### PR DESCRIPTION
## Issue
#39 

## 内容
- routes/posts.jsのgetPostsByPaginationとgetUserPostsの2つのミドルウェアの投稿ルートのURLが被っていたので区別できるように修正