### PR TITLE
【投稿モデル】投稿モデルにpropertyという物件名のカラムを追加

### DIFF
--- a/controllers/post-controller.js
+++ b/controllers/post-controller.js
@@ -1,6 +1,6 @@
 const db = require('../models/index');
 
-const attributes = ['id', 'title', 'text', 'updatedAt'];
+const attributes = ['id', 'title', 'property', 'text', 'updatedAt'];
 const userAttributes = ['id', 'username', 'icon_url'];
 const answerAttributes = ['id', 'content', 'updatedAt'];
 const addressAttributes = [

--- a/controllers/user-controller.js
+++ b/controllers/user-controller.js
@@ -2,7 +2,7 @@ const db = require('../models/index');
 const bcrypt = require('bcrypt');
 
 const userAttributes = ['id', 'username', 'icon_url', 'self_introduction'];
-const postAttributes = ['id', 'title'];
+const postAttributes = ['id', 'title', 'property'];
 const answerAttributes = ['id', 'content', 'updatedAt'];
 
 

--- a/migrations/20210831052240-post.js
+++ b/migrations/20210831052240-post.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+     return [
+      queryInterface.addColumn('posts', 'property', {
+        type: Sequelize.STRING,
+        after: 'title',
+      })
+    ];
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  }
+};

--- a/migrations/20210831053046-post.js
+++ b/migrations/20210831053046-post.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    /**
+     * Add altering commands here.
+     *
+     * Example:
+     * await queryInterface.createTable('users', { id: Sequelize.INTEGER });
+     */
+     return [
+      queryInterface.addColumn('posts', 'property', {
+        type: Sequelize.STRING,
+        after: 'title',
+      })
+    ];
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    /**
+     * Add reverting commands here.
+     *
+     * Example:
+     * await queryInterface.dropTable('users');
+     */
+  }
+};


### PR DESCRIPTION
## Issue
#43 

## 内容
- 投稿モデルに不動産物件名を記述できるカラム(property)を追加しマイグレーションを実行
- 投稿モデルのデータを参照する際に物件カラム(property)も参照できるようにミドルウェアのattributesに追加