### PR TITLE
【ページネーション機能】投稿取得ミドルウェアにページネーション機能を追加 

### DIFF
--- a/routes/posts.js
+++ b/routes/posts.js
@@ -5,30 +5,58 @@ const postController = require('../controllers/post-controller');
 // 特定数の投稿を取得
 router.get(
   '/page/:page',
-  postController.getPostsByPagination,
+  postController.getPosts,
   postController.errorHandling
 );
 
 // 特定のユーザーの投稿一覧を取得
-router.get('/:userId', postController.getUserPosts, postController.errorHandling);
+router.get(
+  '/:userId/page/:page',
+  postController.getUserPosts,
+  postController.errorHandling
+);
 
 // フォローしているユーザーたちの投稿一覧を取得
-router.post('/followee', postController.getFolloweePosts, postController.errorHandling);
+router.post(
+  '/followee/page/:page',
+  postController.getFolloweePosts,
+  postController.errorHandling
+);
 
 // 特定の投稿を取得
-router.get('/post/:postId', postController.getPost, postController.errorHandling);
+router.get(
+  '/post/:postId',
+  postController.getPost,
+  postController.errorHandling
+);
 
 // 投稿を作成
-router.post('/post/new', postController.createPost, postController.errorHandling);
+router.post(
+  '/post/new',
+  postController.createPost,
+  postController.errorHandling
+);
 
 // 投稿を編集
-router.patch('/update/:postId', postController.updatePost, postController.errorHandling);
+router.patch(
+  '/update/:postId',
+  postController.updatePost,
+  postController.errorHandling
+);
 
 // 投稿を削除
-router.delete('/delete/:postId', postController.deletePost, postController.errorHandling);
+router.delete(
+  '/delete/:postId',
+  postController.deletePost,
+  postController.errorHandling
+);
 
 // お気に入りの投稿を作成
-router.post('/create/favorite', postController.setFavoritePost, postController.errorHandling);
+router.post(
+  '/create/favorite',
+  postController.setFavoritePost,
+  postController.errorHandling
+);
 
 // お気に入りの投稿を削除
 router.delete(


### PR DESCRIPTION
## Issue 
#51 

## 概要
- ログインユーザーの投稿取得ミドルウェア、フォローしているユーザーの投稿取得ミドルウェアにページネーション機能を追加
- 投稿一覧取得時に総ページ数を取得できるように変更
- 変更に伴って投稿ミドルウェアのルートを修正

## 動作確認
ホームページの投稿表示下部にページネーションのボタンがあるので、そこを押して投稿が切り替わることを確認