### PR TITLE
投稿の取得件数を変更 

### DIFF
--- a/controllers/post-controller.js
+++ b/controllers/post-controller.js
@@ -46,7 +46,7 @@ const favoritePostsAssociation = {
   as: "favoritePosts",
 };
 
-const perPage = 1; // 1ページ当たりの投稿数
+const perPage = 10; // 1ページ当たりの投稿数
 
 const postController = {
   // 特定数の投稿を取得


### PR DESCRIPTION
## Issue
#53 

## 概要
上記のイシューで投稿の取得件数を変更したままだったので、修正した

以下詳細
- 1ページ当たりの取得投稿件数を10件に変更

## 動作確認内容
ローカル上でホームページにアクセスして投稿が10件表示されることを確認