### PR TITLE
【回答機能】回答の順番を日付の降順にする

### DIFF
--- a/controllers/post-controller.js
+++ b/controllers/post-controller.js
@@ -56,9 +56,7 @@ const postController = {
       .findAndCountAll({
         offset: (page - 1) * perPage,
         limit: perPage,
-        order: [
-          ["updatedAt", "DESC"], // 投稿日時が遅い順
-        ],
+        order: [["updatedAt", "DESC"]],
         attributes,
         include: [
           userAssociation,
@@ -170,6 +168,7 @@ const postController = {
           },
           categoryAssociation,
         ],
+        order: [[db.answer, "updatedAt", "ASC"]],
       })
       .then((result) => {
         res.json(result);
@@ -271,9 +270,7 @@ const postController = {
       offset: (page - 1) * perPage,
       limit: perPage,
       attributes,
-      order: [
-        ["updatedAt", "DESC"], // 投稿日時が遅い順
-      ],
+      order: [["updatedAt", "DESC"]],
       include: [
         userAssociation, // 投稿者
       ],


### PR DESCRIPTION
## Issue
#56 

## 概要
投稿詳細ページに表示される回答の順番を日付の降順に変更

以下詳細
- 投稿ミドルウェアgetPostのorderの設定を変更

## 動作確認内容
投稿詳細ページにアクセスして回答が日付の降順になっていることを確認
