### PR TITLE
【エラーハンドリング】データが重複したときのエラー処理を追加

### DIFF
--- a/migrations/20210929150451-edit-auth-settings.js
+++ b/migrations/20210929150451-edit-auth-settings.js
@@ -1,0 +1,17 @@
+"use strict";
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    queryInterface.changeColumn("users", "password", {
+      type: Sequelize.STRING,
+      unique: true,
+      allowNull: false,
+    });
+    queryInterface.changeColumn("users", "username", {
+      type: Sequelize.STRING,
+      unique: true,
+      allowNull: false,
+    });
+  },
+  down: async (queryInterface, Sequelize) => {},
+};

--- a/migrations/20210929152805-edit-user.js
+++ b/migrations/20210929152805-edit-user.js
@@ -1,0 +1,12 @@
+"use strict";
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    queryInterface.changeColumn("users", "email", {
+      type: Sequelize.STRING,
+      unique: true,
+      allowNull: false,
+    });
+  },
+  down: async (queryInterface, Sequelize) => {},
+};


### PR DESCRIPTION
## Issue
#58 

## 概要
- ユーザーテーブルの設定を変更しマイグレーションを実行
- 重複したデータを保存するときに発生するエラーにメッセージとエラーが起こっているカラム名を返す機能を追加

## 動作確認内容
ローカル環境でページにアクセスして以下を確認

新規登録画面
1. usernameまたはemailに重複している値を入力してボタンを押す
2. 入力欄の下にバリデーションメッセージが表示されることを確認

プロフィール編集画面
1. usernameに重複した値を入力して保存ボタンを押す
2. 入力欄の下にバリデーションメッセージが表示されていることを確認

マイページ
1. 右のサイドメニューから[設定] > [認証情報]をクリック
2. Emailの編集画面が表示されたら、重複したEmailを入力する
3. 保存ボタンを押すとEmailの入力欄の下にバリデーションメッセージが表示されることを確認

## 関連リンク
フロントエンドのプルリク
https://github.com/tko-asn/practice-app-vue2/pull/58